### PR TITLE
Double buffering

### DIFF
--- a/V_test_end.f90
+++ b/V_test_end.f90
@@ -6,7 +6,8 @@ program V_test_end
 
    integer                                 ::nvx,nvy,nvz !numero de grilla
    integer                                 ::pnum,N_iter !numero de particulas, numero de iteraciones
-   real(np),dimension(:,:,:),allocatable   ::V,V0        !voltaje nuevo y anterior
+   real(np),dimension(:,:,:,:),allocatable,target :: Vstorage
+   real(np),dimension(:,:,:),pointer       ::V,V0,Vtmp        !voltaje nuevo y anterior
    !real(np),dimension(:,:,:),allocatable   ::Vx,Vy,Vz,V0x,V0y,V0z !componentes
    !real(np)                                ::dv
    real(np)                                ::Vtop !Vtop es el valor del voltaje en la tapa
@@ -80,9 +81,12 @@ program V_test_end
    write(*,*) 'Ya leyó las posiciones finales'
 
    !Variables del potencial
-   allocate(V(0:nvx+1,0:nvy+1,0:nvz+1))
+   allocate(Vstorage(0:nvx+1,0:nvy+1,0:nvz+1,2))
+
+   V0(0:,0:,0:)=>Vstorage(:,:,:,1)
+   V(0:,0:,0:)=>Vstorage(:,:,:,2)
+
    write(*,*) 'size V',size(V,dim=1)
-   allocate(V0(0:nvx+1,0:nvy+1,0:nvz+1))
    write(*,*) 'size V0',size(V0,dim=3)
 
    !Condicion inicial - construyo el gradiente de voltaje en la dirección z
@@ -129,8 +133,10 @@ program V_test_end
          write(*,*) 'N_iter=',l,"Res",res
       endif
 
-      ! Avance
-      V0(:,:,:)=V(:,:,:)
+      ! Swap pointers
+      Vtmp=>V0
+      V0(0:,0:,0:)=>V(:,:,:)
+      V(0:,0:,0:)=>Vtmp(:,:,:)
 
       ! Metal es cero
       !$OMP PARALLEL DO PRIVATE(N,RI,RJ,RK)

--- a/V_test_end.f90
+++ b/V_test_end.f90
@@ -130,13 +130,7 @@ program V_test_end
       endif
 
       ! Avance
-      V0(1:nvx,1:nvy,1:nvz)=V(1:nvx,1:nvy,1:nvz)
-
-      ! PBC
-      V0(nvx+1,1:nvy,1:nvz)=V(1,1:nvy,1:nvz)
-      V0(0,1:nvy,1:nvz)=V(nvx,1:nvy,1:nvz)
-      V0(1:nvx,nvy+1,1:nvz)=V(1:nvx,1,1:nvz)
-      V0(1:nvx,0,1:nvz)=V(1:nvx,nvy,1:nvz)
+      V0(:,:,:)=V(:,:,:)
 
       ! Metal es cero
       !$OMP PARALLEL DO PRIVATE(N,RI,RJ,RK)

--- a/V_test_end.f90
+++ b/V_test_end.f90
@@ -80,13 +80,13 @@ program V_test_end
    write(*,*) 'Ya leyó las posiciones finales'
 
    !Variables del potencial
-   allocate(V(nvx,nvy,nvz))
+   allocate(V(0:nvx+1,0:nvy+1,0:nvz+1))
    write(*,*) 'size V',size(V,dim=1)
    allocate(V0(0:nvx+1,0:nvy+1,0:nvz+1))
    write(*,*) 'size V0',size(V0,dim=3)
 
-   !V0(:,:,:) = 0._np
-   !V(:,:,:) = 0._np
+   V0(:,:,:) = 0._np
+   V(:,:,:) = 0._np
 
    !Condicion inicial - construyo el gradiente de voltaje en la dirección z
    Vtop=10._np
@@ -132,13 +132,13 @@ program V_test_end
       endif
 
       ! Avance
-      V0(1:nvx,1:nvy,1:nvz)=V(:,:,:)
+      V0(1:nvx,1:nvy,1:nvz)=V(1:nvx,1:nvy,1:nvz)
 
       ! PBC
-      V0(nvx+1,1:nvy,1:nvz)=V(1,:,:)
-      V0(0,1:nvy,1:nvz)=V(nvx,:,:)
-      V0(1:nvx,nvy+1,1:nvz)=V(:,1,:)
-      V0(1:nvx,0,1:nvz)=V(:,nvy,:)
+      V0(nvx+1,1:nvy,1:nvz)=V(1,1:nvy,1:nvz)
+      V0(0,1:nvy,1:nvz)=V(nvx,1:nvy,1:nvz)
+      V0(1:nvx,nvy+1,1:nvz)=V(1:nvx,1,1:nvz)
+      V0(1:nvx,0,1:nvz)=V(1:nvx,nvy,1:nvz)
 
       ! Metal es cero
       !$OMP PARALLEL DO PRIVATE(N,RI,RJ,RK)
@@ -174,7 +174,7 @@ contains
 
       integer,intent(in) :: nvx,nvy,nvz
       real(np),dimension(0:nvx+1,0:nvy+1,0:nvz+1),intent(in) :: V0
-      real(np),dimension(1:nvx,1:nvy,1:nvz),intent(out) :: V
+      real(np),dimension(0:nvx+1,0:nvy+1,0:nvz+1),intent(out) :: V
       real(np),intent(out) :: res
 
       integer :: i,j,k

--- a/V_test_end.f90
+++ b/V_test_end.f90
@@ -95,7 +95,7 @@ program V_test_end
       V0(:,:,i)=real(i,dp)/(nvz+1)*Vtop
    enddo
 
-   V(:,:,:) = V0(:,:,:) ! TODO: refine
+   V(:,:,:)=V0(:,:,:) ! TODO: refine
    V(1:nvx,1:nvy,1:nvz)=V0(2:nvx+1,2:nvy+1,2:nvz+1)
 
    !Condicion de metal - Se asigna voltaje nulo a la posciones de la malla donde haya estructura de dendritas
@@ -177,7 +177,7 @@ contains
 
       integer :: i,j,k
 
-      res = 0._np
+      res=0._np
       !$omp parallel do private(i,j,k) reduction(+:res)
       do k=1,nvz
          do j=1,nvy
@@ -191,7 +191,6 @@ contains
       !$omp end parallel do
    endsubroutine step
 
-
    subroutine step_pbc(V0,nvx,nvy,nvz,V,res)
       implicit none
 
@@ -202,7 +201,7 @@ contains
 
       integer :: i,j,k
 
-      res = 0._np
+      res=0._np
       !$omp parallel do private(i,j,k) reduction(+:res)
       do k=1,nvz
          do j=1,nvy
@@ -211,15 +210,14 @@ contains
                res=res+((V0(i,j,k)-V(i,j,k))**2)
                !if(abs(V(i,j,k)-V0(i,j,k))>1.e-5_dp) print *, "WARNING"
             enddo
-            V(nvx+1,j,k) = V(1,j,k)
-            V(0,j,k) = V(nvx,j,k)
+            V(nvx+1,j,k)=V(1,j,k)
+            V(0,j,k)=V(nvx,j,k)
          enddo
-         V(1:nvx,nvy+1,k) = V(1:nvx,1,k)
-         V(1:nvx,0,k) = V(1:nvx,nvy,k)
+         V(1:nvx,nvy+1,k)=V(1:nvx,1,k)
+         V(1:nvx,0,k)=V(1:nvx,nvy,k)
       enddo
       !$omp end parallel do
    endsubroutine step_pbc
-
 
    subroutine salida(archivo,r)
       character(*),intent(in)  :: archivo

--- a/V_test_end.f90
+++ b/V_test_end.f90
@@ -85,15 +85,13 @@ program V_test_end
    allocate(V0(0:nvx+1,0:nvy+1,0:nvz+1))
    write(*,*) 'size V0',size(V0,dim=3)
 
-   V0(:,:,:) = 0._np
-   V(:,:,:) = 0._np
-
    !Condicion inicial - construyo el gradiente de voltaje en la dirección z
    Vtop=10._np
    do i=0,nvz+1
       V0(:,:,i)=real(i,dp)/(nvz+1)*Vtop
    enddo
 
+   V(:,:,:) = V0(:,:,:) ! TODO: refine
    V(1:nvx,1:nvy,1:nvz)=V0(2:nvx+1,2:nvy+1,2:nvz+1)
 
    !Condicion de metal - Se asigna voltaje nulo a la posciones de la malla donde haya estructura de dendritas


### PR DESCRIPTION
- Agrandar V al tamaño de V0 para poder hacer lo que sigue.
- En vez de copiar V a V0 al final de cada iteración, usar dos punteros para V y V0 y darlos vuelta al final de la iteración. Esto mejora mucho la performance.
- Fusionar las condiciones de contorno con el kernel `step`.
- Sacar el loop de metal repetido a una subrutina, y reubicar la llamada. No sé cuál es el nombre apropiado para esto, le puse `dendritas`.
- Algo de limpieza de la función `salida`.

El output da ligeramente distinto en la columna `Vpp` pero no sé si es numérico o hay algo metiendo ruido. Alguien que sepa de esto tiene que revisarlo.